### PR TITLE
Add mruby-env dependency

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,6 @@
 MRuby::Gem::Specification.new('mruby-getoptlong') do |spec|
   spec.license = 'MIT'
   spec.author  = 'Sergio Rubio <rubiojr@frameos.org>'
+  
+  spec.add_dependency('mruby-env')
 end


### PR DESCRIPTION
mruby-getoptlong still uses ENV, so mruby-env should be listed as a dependency.
